### PR TITLE
Remove unused copyright field from config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,5 @@
 title: "Lincoln Mullen"
 description: "Lincoln Mullen is a historian of American religion and the nineteenth-century United States."
-copyright: "2008-2022"
 
 permalinks:
   blog: "/:section/:slug/"


### PR DESCRIPTION
## Summary
- Removes the `copyright: "2008-2022"` field from config.yaml

## Rationale
- The copyright field is only used in the RSS feed XML `<copyright>` tag
- It's an optional element per RSS 2.0 specification
- It was outdated (stopped at 2022)
- Not displayed anywhere on the visible website
- No functional impact on the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)