### PR TITLE
Add baseURL to Cloudflare build command

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,7 +2,7 @@
 	"name": "lincolnmullen-dot-com",
 	"compatibility_date": "2025-01-29",
 	"build": {
-		"command": "hugo --cleanDestinationDir --minify"
+		"command": "hugo --cleanDestinationDir --minify --baseURL \"https://lincolnmullen.com\""
 	},
 	"assets": {
 		"directory": "./public",


### PR DESCRIPTION
The Cloudflare build in wrangler.jsonc was missing --baseURL, causing
Hugo to generate relative URLs for all resources including images. Feed
readers require absolute URLs to display images from RSS and JSON feeds.
This matches the Makefile build command which already includes baseURL.

https://claude.ai/code/session_011m1zrF1D7QXdAHeEzRQgPo