### PR TITLE
Add social media and description fields to blog post schema

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -38,7 +38,7 @@ The blog list page combines posts from `blog/`, `micro/`, and `newsletter/` sect
 
 **Blog posts** (`content/blog/YYYY-MM-DD-slug/index.md`):
 - Required: `title`, `date`, `slug`, `draft`
-- Optional: `newsletter: true`, `crosspost: {url, source}`, `linkpost: "url"`
+- Optional: `description`, `newsletter: true`, `crosspost: {url, source}`, `linkpost: "url"`, `social: {bluesky, mastodon, linkedin}`
 
 **Micro posts** (`content/micro/YYYY-MM-DD-HH-MM-SS.md`):
 - Required: `date`
@@ -54,12 +54,44 @@ Use the `figure` shortcode for images with a caption, and the `image` shortcode 
 - `{{</* image src="file.jpg" alt="description" */>}}` - Responsive images with WebP conversion
 - `{{</* image src="file.gif" */>}}` - GIFs and SVGs pass through without processing
 
-## Social Media Text Generation
+## Social Media Text and Description Generation
 
-When asked to generate social media posts for a piece of content, read the post file and produce platform-specific drafts:
+When asked to generate social media posts for a blog post, read the post file and write the text directly into the post's YAML front matter fields. Generate all of the following at once:
 
-- **BlueSky**: ≤300 characters. Conversational, informal tone. End with the permalink URL. No hashtags.
-- **Mastodon**: ≤500 characters. Similar tone to BlueSky, slightly more room for detail. End with the permalink URL. No hashtags.
-- **LinkedIn**: One or two short paragraphs. More professional framing, emphasizing scholarly or institutional significance. End with the permalink URL. No hashtags.
+### Description
+
+Write the `description` field: 1–2 sentences summarizing the post for meta tags and OpenGraph previews. This should be platform-neutral, informative, and suitable for search engine results. It is not a social media post.
+
+### Social media fields
+
+Write the `social:` block fields (`bluesky`, `mastodon`, `linkedin`) in the front matter:
+
+- **bluesky**: ≤300 characters (including the URL). Conversational, informal tone. End with the permalink URL. No hashtags.
+- **mastodon**: ≤500 characters (including the URL). Similar tone to BlueSky, slightly more room for detail. End with the permalink URL. No hashtags.
+- **linkedin**: One or two short paragraphs. More professional framing, emphasizing scholarly or institutional significance. End with the permalink URL. No hashtags.
 
 For all platforms: capture the main point or most interesting detail of the post, not just the title. For linkposts, summarize what makes the linked item worth reading.
+
+### Permalink URL
+
+The permalink URL for blog posts follows the pattern `https://lincolnmullen.com/blog/<slug>/`, where `<slug>` is the `slug` field in the front matter. Include this URL at the end of each social media text.
+
+### YAML formatting
+
+- For `description`, `bluesky`, and `mastodon`, use double-quoted strings on a single line.
+- For `linkedin`, if the text is multi-paragraph, use the YAML literal block scalar (`|`) to preserve line breaks. If it fits on one line, a double-quoted string is fine.
+
+### Example
+
+Here is an example of what a blog post's front matter should look like after generation:
+
+```yaml
+description: "A summary of what the example post is about, suitable for meta tags and search results."
+social:
+  bluesky: "Here's an interesting take on the example topic. https://lincolnmullen.com/blog/example-post-title/"
+  mastodon: "Here's a slightly longer take on the example topic, with a bit more room for detail and nuance. https://lincolnmullen.com/blog/example-post-title/"
+  linkedin: |
+    I recently wrote about the example topic, which has significant implications for the field.
+
+    The post explores how this matters for scholars and institutions working in this area. https://lincolnmullen.com/blog/example-post-title/
+```

--- a/archetypes/blog/index.md
+++ b/archetypes/blog/index.md
@@ -3,11 +3,16 @@ title: "{{ getenv "BLOG_TITLE" }}"
 date: "{{ .Date  }}"
 slug: "{{ slicestr .Name 11  }}"
 draft: true
+description: ""
 # newsletter: true
 # tags:
-# - 
-# crosspost: 
+# -
+# crosspost:
 #   url: ""
 #   source: ""
 # linkpost: ""
+social:
+  bluesky: ""
+  mastodon: ""
+  linkedin: ""
 ---


### PR DESCRIPTION
## Summary
Updated the blog post content schema and documentation to support generating and storing social media text and meta descriptions directly in post front matter, rather than as separate outputs.

## Key Changes

- **Schema updates**: Added `description` field and `social` block (with `bluesky`, `mastodon`, `linkedin` subfields) to the optional front matter for blog posts
- **Documentation expansion**: Rewrote the "Social Media Text Generation" section to "Social Media Text and Description Generation" with detailed guidance on:
  - Writing platform-specific social media text with character limits and tone guidelines
  - Generating meta description for search engines and OpenGraph previews
  - Proper YAML formatting for single-line strings and multi-paragraph literal blocks
  - Permalink URL construction pattern
  - Complete example showing the expected front matter structure
- **Archetype update**: Modified the blog post archetype template to include the new `description` and `social` fields with empty defaults, making them available when creating new posts

## Implementation Details

The social media fields follow platform-specific constraints:
- **BlueSky**: ≤300 characters (conversational, informal)
- **Mastodon**: ≤500 characters (similar tone with more detail)
- **LinkedIn**: 1-2 paragraphs (professional framing)

All social media text should end with the post's permalink URL and avoid hashtags. The description field is separate from social media text and is optimized for meta tags and search results.

https://claude.ai/code/session_01SScGsQjPrZ8dcaefwV8n3D