### PR TITLE
Add explicit slug frontmatter to blog posts

### DIFF
--- a/content/blog/2014-12-11-uses-this/index.md
+++ b/content/blog/2014-12-11-uses-this/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Interview at *Uses This*"
 date: 2014-12-11
+slug: 'uses-this'
 tags:
 - Unix
 - software

--- a/content/blog/2022-04-11-good-mentor/index.md
+++ b/content/blog/2022-04-11-good-mentor/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'What makes for a good academic mentor?'
 date: 2022-04-11
+slug: 'good-mentor'
 draft: false
 tags:
 - mentoring

--- a/content/blog/2022-09-07-gmu-library-proxy/index.md
+++ b/content/blog/2022-09-07-gmu-library-proxy/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Bookmarklet for the GMU library proxy'
 date: 2022-09-07
+slug: 'gmu-library-proxy'
 draft: false
 tags:
 - library


### PR DESCRIPTION
## Summary
Added explicit `slug` frontmatter fields to three blog post files to ensure consistent URL generation and improve control over post permalinks.

## Changes
- Added `slug: 'uses-this'` to the "Interview at Uses This" post (2014-12-11)
- Added `slug: 'good-mentor'` to the "What makes for a good academic mentor?" post (2022-04-11)
- Added `slug: 'gmu-library-proxy'` to the "Bookmarklet for the GMU library proxy" post (2022-09-07)

## Details
Each slug is placed in the frontmatter immediately after the `date` field and uses a kebab-case format derived from the post title. This explicit configuration allows for better control over URL generation and makes the intended permalink structure more transparent in the source files.

https://claude.ai/code/session_01LdRcXkb5Fk1S5pMf6Agqbz