### PR TITLE
Simplify OpenGraph image logic

### DIFF
--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -29,11 +29,6 @@ Image resolution:
 
 {{- /* Determine canonical URL */ -}}
 {{- $url := .Permalink -}}
-{{- if .Params.External -}}
-  {{- $url = .Params.External.URL -}}
-{{- else if .Params.linkpost -}}
-  {{- $url = .Params.linkpost -}}
-{{- end -}}
 
 {{- /* Determine page type */ -}}
 {{- $type := "website" -}}


### PR DESCRIPTION
## Summary
- Simplify OpenGraph image resolution from 6 fallback steps to 2: use `image:` front matter (page bundle or global asset), or fall back to default image
- Remove automatic image detection by convention names (`*feature*`, `*cover*`, `*thumbnail*`), first-image-in-bundle scanning, and `absURL` static file fallback
- Always use the post's own permalink as the canonical `og:url`, instead of overriding with external link URLs for link posts

Closes #112

## Test plan
- [ ] Run `hugo serve` and verify build succeeds
- [ ] Check a micro post with `image:` front matter — `og:image` should use that image
- [ ] Check a blog post without `image:` front matter — `og:image` should use default social media image
- [ ] Check a link post — `og:url` should point to the site, not the external URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)