### PR TITLE
Use RelPermalink for local assets so preview deployments work

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -30,7 +30,7 @@
 
 	{{ $options := (dict "targetPath" "css/styles.css" "outputStyle" "compressed") }}
 	{{ $style := resources.Get "scss/main.scss" | toCSS  $options | resources.Minify | resources.Fingerprint "md5" }}
-	<link rel="stylesheet" href="{{ $style.Permalink }}">
+	<link rel="stylesheet" href="{{ $style.RelPermalink }}">
 
 	<!-- shortcut icons -->
 	<link rel="shortcut icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>">

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -6,12 +6,12 @@
 	{{ $regular := $raw.Resize "702x webp"}}
 	{{ $retina := $raw.Resize "1404x webp"}}
 	{{ $link := .Get "link" }}
-	<a href="{{ $link | default $raw.Permalink }}">
-		<img class="img-fluid" src='{{ $regular.Permalink }}' srcset="{{ $regular.Permalink }}, {{ $retina.Permalink }} 2x" alt='{{ .Get "caption" | markdownify | plainify }}'>
+	<a href="{{ $link | default $raw.RelPermalink }}">
+		<img class="img-fluid" src='{{ $regular.RelPermalink }}' srcset="{{ $regular.RelPermalink }}, {{ $retina.RelPermalink }} 2x" alt='{{ .Get "caption" | markdownify | plainify }}'>
 	</a>
 	{{ else }}
 	<!-- Don't process GIFs or SVGs -->
-	<img class="img-fluid" src='{{ $raw.Permalink }}' alt='{{ .Get "caption" | markdownify | plainify }}' />
+	<img class="img-fluid" src='{{ $raw.RelPermalink }}' alt='{{ .Get "caption" | markdownify | plainify }}' />
 	{{ end }}
 	<figcaption class="ms-5">
 		<p>

--- a/layouts/shortcodes/image.html
+++ b/layouts/shortcodes/image.html
@@ -12,17 +12,17 @@
 {{ $original := .Get "original" }}
 {{ if or (eq $ext ".gif") (eq $ext ".svg") }}
 <!-- Don't process GIFs or SVGs -->
-<a href="{{ $link | default $raw.Permalink }}">
-	<img class="img-fluid mt-2 mb-4" src='{{ $raw.Permalink }}' alt='{{ .Get "alt" | plainify }}' />
+<a href="{{ $link | default $raw.RelPermalink }}">
+	<img class="img-fluid mt-2 mb-4" src='{{ $raw.RelPermalink }}' alt='{{ .Get "alt" | plainify }}' />
 </a>
 {{ else if (eq $original "true")}}
-<a href="{{ $link | default $raw.Permalink }}">
-	<img class="img-fluid mt-2 mb-4" src='{{ $raw.Permalink }}' alt='{{ .Get "alt" | plainify }}' />
+<a href="{{ $link | default $raw.RelPermalink }}">
+	<img class="img-fluid mt-2 mb-4" src='{{ $raw.RelPermalink }}' alt='{{ .Get "alt" | plainify }}' />
 </a>
 {{ else }}
 {{ $regular := $raw.Resize "702x webp"}}
 {{ $retina := $raw.Resize "1404x webp"}}
-<a href="{{ $link | default $raw.Permalink }}">
-	<img class="img-fluid my-4" src='{{ $regular.Permalink }}' srcset="{{ $regular.Permalink }} 1x, {{ $retina.Permalink }} 2x" alt='{{ .Get "alt" | plainify }}' />
+<a href="{{ $link | default $raw.RelPermalink }}">
+	<img class="img-fluid my-4" src='{{ $regular.RelPermalink }}' srcset="{{ $regular.RelPermalink }} 1x, {{ $retina.RelPermalink }} 2x" alt='{{ .Get "alt" | plainify }}' />
 </a>
 {{ end }}


### PR DESCRIPTION
## Summary
- Switches `.Permalink` to `.RelPermalink` for CSS and image assets in `baseof.html`, `figure.html`, and `image.html` shortcodes
- Fixes #142: preview branch deployments were missing CSS and images because absolute URLs pointed to the production domain

## Test plan
- [ ] Verify the site builds without errors
- [ ] Check that CSS loads correctly on preview branch deployments
- [ ] Check that images render correctly in posts using `figure` and `image` shortcodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)