### PR TITLE
Import two syllabi from Canvas as course pages

### DIFF
--- a/content/courses/_index.md
+++ b/content/courses/_index.md
@@ -7,10 +7,10 @@ aliases:
 I teach courses in American religion, the global history of Christianity, the nineteenth-century United States, and in particular on digital history and computational history. All of my syllabi are available below.
 
 <table id="syllabus-list" class="date-list-table table table-borderless align-top">
-  <tr><td class="semester">Spring 2026</td> <td><a href="https://canvas.gmu.edu/courses/71778">American Scriptures</a></td></tr>
+  <tr><td class="semester">Spring 2026</td> <td><a href="/courses/scriptures.2026/">American Scriptures</a></td></tr>
   <tr><td class="semester">Fall 2026</td> <td>The Digital Past: Reconstruction and Redemption</td></tr>
   <tr><td class="semester">Spring 2025</td> <td><a href="/courses/data.2025/">Data Analysis for History</a></td></tr>
-  <tr><td class="semester">Fall 2024</td> <td><a href="https://canvas.gmu.edu/courses/25783/">Global History of Christianity</a></td></tr>
+  <tr><td class="semester">Fall 2024</td> <td><a href="/courses/christianity.2024/">Global History of Christianity</a></td></tr>
   <tr><td class="semester">Spring 2024</td> <td><a href="/courses/scriptures.2024/">American Scriptures</a></td></tr>
   <tr><td class="semester">Fall 2023</td> <td><a href="/courses/capitalism.2023/">Capitalism and American Religion</a></td></tr>
   <tr><td class="semester">Spring 2023</td> <td><a href="/courses/christianity.2023/">Global History of Christianity</a></td></tr>

--- a/content/courses/christianity.2024/index.md
+++ b/content/courses/christianity.2024/index.md
@@ -1,0 +1,276 @@
+---
+title: Global History of Christianity
+semester: Fall
+year: 2024
+department: Department of History and Art History
+university: George Mason University
+coursenum: HIST 384 and RELI 384
+courseurl: https://historyarthistory.gmu.edu/courses/hist384
+credits: 3
+meets: Tuesdays and Thursdays, 10:30am to 11:45am
+room: Horizon Hall 2008
+instructor: Lincoln Mullen
+instructorurl: https://lincolnmullen.com
+email: lmullen@gmu.edu
+office: Research Hall 483
+officehours: "By appointment"
+toc: true
+draft: false
+---
+
+## Course description
+
+This course is organized around a comparative examination of the many forms global Christianity has taken over the past two thousand years. Chronologically, it begins with the ancient Jewish, Greek, and Roman contexts of early Christianity and continues through the present. Students will become familiar with many kinds of Christianity across the globe, including Asian, African, Latin American, European, and North American Christianities. In each geographic and chronological context, students will explore several themes, including the adaptation of Christianity to local cultures, the transmission and reception of Christianity, the translation and use of sacred texts, the experiences of a typical church service, and the relationship between Christianity and politics. Students will also consider Christianity as an element of global systems organized around missions, empire, migration, trade, and warfare.
+
+## Learning goals
+
+At the end of this course, you will
+
+1. be familiar with Christianity in a variety of global contexts across time;
+2. understand the historic development of Christian beyond the West as well as the later reception of Christianity in non-Western cultures;
+3. understand key questions of transmission, reception, and inculturation that affect Christianity's relationship to empire and other global systems;
+4. demonstrate specific knowledge of topics in the history of Christianity, such as Christendom, the Reformation, missions, and Pentecostalism; and
+5. be able to write clearly and coherently about the history of Christianity.
+
+This course fulfills the Mason Core requirement for [Global Contexts](https://catalog.gmu.edu/mason-core/), and you will also meet those learning goals in addition to the course-specific learning goals. Upon completing a Global Contexts course, students will be able to
+
+- identify and explain how patterns of global connections across nations and/or cultures have shaped societies to create interdependence and inequality.
+- use a disciplinary lens to demonstrate knowledge of how at least one nation and/or culture participates in or is affected by global contexts.
+- apply an understanding of one's own positionality within a globally interdependent and unequal world to analyze solutions to global problems.
+
+In addition, this course meets the requirements for the Just Societies flag. Upon completing a Just Societies course, students will be able to demonstrate the following competencies:
+
+- (a) Define key terms related to justice, equity, diversity, and inclusion as related to this course's field/discipline and (b) use those terms to engage meaningfully with peers about course issues.
+- Articulate obstacles to justice and equity, and strategies for addressing them, in response to local, national, and/or global issues in the field/discipline.
+
+## Essential information
+
+This class will include a combination of lecture, discussion, and active learning. Doing the reading is absolutely essential. There will be a reading quiz every class period: if you've done the reading, you can expect to do well on the quizzes. Attend class having read any assigned material and be prepared to discuss or otherwise engage with those readings in class. You must have a copy of the texts assigned for each day available to you during class (electronic copies are fine).
+
+We will be using Canvas for many course activities, so you will need a way to access Canvas during the class period (laptop, possibly a phone or tablet).
+
+The best place to ask general questions about the class is the Canvas discussion board. That way, if your question is relevant to everyone, they will be able to see it. If your question is individual, you are welcome to use the Canvas messaging feature (please try this first) or to email me (<lmullen@gmu.edu>). You can generally expect a response within 24--48 hours, though never on a Sunday.
+
+You are always welcome to talk with me during office hours. To do so, please [book an appointment](/page/office-hours/). If the scheduled times don't work for you, contact me and suggest a few other times that would work for you. I try to come to class early and stay briefly after class for short conversations.
+
+**Required readings.** These books are required. Any edition will do. Some of the required books may be available in the GMU libraries through [TextSelect Textbook Reserves](https://library.gmu.edu/textselect). All other readings will be available on Canvas or through the GMU libraries.
+
+- Wilken, Robert Louis. _The First Thousand Years: A Global History of Christianity_. Yale University Press, 2013.
+- Holland, Tom. _Dominion: How the Christian Revolution Remade the World_. Basic Books, 2019.
+
+Although you can find the Bible for free in many places and don't strictly need one for this course, I encourage you to get a paper copy. My recommended edition is _The New Oxford Annotated Bible with Apocrypha: New Revised Standard Version_ (ISBN: 978-0190276089), which is about the closest you can get to a standard scholarly edition.
+
+## Assignments
+
+Grades will be based on the assignments listed below. Please turn in all assignments on Canvas.
+
+*Reading quizzes (25%).* Every class will include a brief quiz over the assigned readings. There are no makeup quizzes or late quizzes, but an absence (or at most two) will not hurt your overall grade.
+
+*Short writing assignments (4 × 5% each = 20%).* Four short writing assignments are due before the start of class on the day assigned. The prompts for these writing assignments are listed in the schedule below. There are nine prompts; you may select any four that you wish to write. These assignments are the basis of class activities that day, so there are no extensions for due date, but your choice of assignment should afford you some flexibility with your schedule. Each assignment should be between 450 and 550 words. Use quotations from the primary sources as your main source of evidence. Use parenthetical citations.
+
+*Midterm exam (25%) and final exam (25%).* Exams will include essay and identification questions.
+
+*Class participation (5%).* Regular attendance and participation in class activities is expected as a matter of course.
+
+Final grades will be calculated using this scale: A+ = 98--100, A = 93--97, A- = 90--92, B+ = 88--89, B = 83--87, B- = 80--82, ... F = 0--59.
+
+## Schedule
+
+### Tues., Aug. 27: Tongues of fire
+
+- In class: Acts of the Apostles, ch. 2.
+
+### Thu., Aug. 29: From Ancient Israel to Rabbinic Judaism
+
+- Isaiah and Daniel.
+- MacCulloch, ch. 2.
+- Holland, ch. 2.
+
+### Tues., Sep. 3: Jesus and the New Testament
+
+- Gospels, opening accounts.
+- Gospel of Mark (entire).
+- Wilken, introduction, chs. 1--2.
+- Holland, ch. 3.
+
+### Thu., Sep. 5: Christians and Pagans
+
+- Acts and Galatians.
+- _Didache_.
+- Justin Martyr, _First Apology_.
+- Wilken, ch. 3.
+- Holland, ch. 1.
+- **DUE: Short writing on early Christian practices:** How do the authors of Acts and Galatians describe conflicts between different groups of early Christians? According to the New Testament readings and the readings from the Didache and Justin Martyr, what were the most significant rituals and practices among early Christians?
+
+### Tues., Sep. 10: Christians and Heretics
+
+- Gospel of Thomas.
+- Wilken, chs. 4, 6.
+
+### Thu., Sep. 12: Christianity and Empire
+
+- _Martyrdom of Perpetua and Felicity_.
+- Wilken, chs. 5, 7, 8, 17.
+
+### Tues., Sep. 17: Councils from Nicaea to Chalcedon
+
+- Creed of Nicaea and Chalcedonian Definition.
+- Wilken, chs. 9, 20.
+- **DUE: Short writing on Nicaea and Chalcedon:** What was the chief question at the Council of Nicaea? How did the Council of Nicaea resolve it? What was the chief question at Chalcedon? How did that church council respond to it? Nicaea and Chalcedon were certainly theological disputes, but in what way was the imperial power involved in those councils?
+
+### Thu., Sep. 19: Augustine, Egeria, and the Making of Latin Christianity
+
+- Egeria, _Pilgrimage_.
+- Augustine, _City of God_, book 14.
+- Wilken, chs. 11, 18, 19.
+
+### Tues., Sep. 24: Catchup
+
+- Readings from previous class period.
+
+### Thu., Sep. 26: Expansion to Northwest Europe
+
+- Bede, _History of the English Church and People_.
+- Patrick, _Confession_.
+- Wilken, chs. 27, 28, 35.
+- Holland, ch. 8.
+
+### Tues., Oct. 1: Syrian and Ethiopian Christianity
+
+- _Kebra Negast_.
+- Wilken, chs. 21--23.
+- **DUE: Short writing on Ethiopian Christianity:** Christianity in Ethiopia developed in parallel to, but distinctly different from, Christianity in Europe. What are the similarities and differences? How do you account for those differences in terms of the global systems that affected Christian development?
+
+### Tues., Oct. 1: Islam and Christianity
+
+- John of Damascus, _Fount of Knowledge_, "On Heresies."
+- Wilken, chs. 30, 32--34.
+- **DUE: Short writing on John of Damascus and Islam:** How does John of Damascus explain Islam within the terms of Christian theology and practice? What arguments does he use in his apologetic? How does John's understanding differ from Islam's own understanding of its origins, and from historians' accounts?
+
+### Thu., Oct. 3: Medieval Christianity and the Middle East
+
+- First Crusade, four accounts.
+- Holland, ch. 10.
+
+### Tues., Oct. 8: Asian and African Christianities
+
+- Cosmas Indicopleustes.
+- John of Ephesus.
+- Chinese Christian sutras.
+- Chinese inscription at Xian.
+- Wilken, ch. 25.
+- **DUE: Short writing on reception in Asia and Africa:** We have read a number of accounts of how Christianity was transmitted to, and received by, populations across the Mediterranean basin, Europe, the Middle East, Asia, and Africa. How was Christianity was received in Asia and Africa? What were the similarities and differences in its reception in other places?
+
+### Thu., Oct. 10: Midterm exam
+
+Bring a bluebook to class.
+
+### Tues., Oct. 15: Byzantine and Russian Christianity
+
+- _Russian Primary Chronicle_.
+- John of Damascus, _On the Divine Images_.
+- Wilken, chs. 24, 31, 36.
+
+### Thu., Oct. 17: Ascetics
+
+- Holland, ch. 5.
+- _Life of Antony_.
+- _Life of Macrina_.
+- **DUE: Short writing on asceticism:** Why were the lives of ascetics appealing to Christians and non-Christians? In what ways did ascetics challenge society or the church?
+
+### Tues., Oct. 22: Monastics and friars
+
+- Rule of St. Benedict.
+- Rule of St. Francis.
+- Wilken, chs. 10, 15, 16.
+
+### Thu., Oct. 24: The Protestant Reformation
+
+- Luther, _Freedom of a Christian_.
+- Luther, 95 Theses.
+- Holland, ch. 13.
+- **DUE: Short writing on Luther:** What is Luther's concept of Christian freedom? In what specific ways does Luther emphasize social and moral discipline in an effort to construct a more godly society?
+
+### Tues., Oct. 29: The Catholic Reformation
+
+- Francis Xavier in Asia.
+- Thomas Aquinas, _Summa Theologiae_, Tertia Pars.
+- Holland, ch. 14.
+
+### Thu., Oct. 31: Spread of Christianity in Asia
+
+- Taiping Rebellion.
+
+### Thu., Nov. 7: Spread of Christianity in Africa
+
+- African ecclesiastical independence.
+
+### Tues., Nov. 12: Enlightenment and Revolutions
+
+- Paine, _Age of Reason_.
+- Schleiermacher, _On Religion_.
+- Holland, chs. 16, 18.
+- **DUE: Short writing on liberal Christianity:** Friedrich Schleiermacher's _On Religion_ attempts to answer Christianity's "cultured despisers." Having read Schleiermacher and Paine, how do you think Schleiermacher would respond to Paine?
+
+### Thu., Nov. 14: Christianity in North and South America
+
+- Gutiérrez, _A Theology of Liberation_.
+- Language in Latin America.
+- Emerson, "Divinity School Address."
+
+### Tues., Nov. 19: Christianity and Missions in the Modern Era
+
+- Missionary societies in Africa.
+- Holland, ch. 17.
+- **DUE: Short writing on ecclesiastical independence:** Missions Christianity in Africa was closely connected with colonization, and yet African Christians have also become independent of European and American churches. What were the processes by which that independence was gained? Draw on your readings for today, but also from earlier weeks, and you may reference Christianity in Asia as well if you wish.
+
+### Thu., Nov. 21: Pentecostalism
+
+- Nimi Wariboko, "Pentecostalism in Africa," _Oxford Research Encyclopedia of African History_ (2017): <https://doi.org/10.1093/acrefore/9780190277734.013.120>.
+
+### Tues., Nov. 26: Colonization and Decolonization
+
+- Holland, ch. 19.
+- McGreevy, ch. 10.
+
+### Tues., Dec. 3: Vatican II
+
+- Vatican II documents.
+- Holland, ch. 20.
+- McGreevy, ch. 11.
+
+### Thu., Dec. 5: Whose religion is Christianity?
+
+- Holland, ch. 21.
+
+### Final exam: Tuesday, Dec. 17, 10:30am--1:15pm
+
+Bring a bluebook to the exam.
+
+## Fine print
+
+This syllabus can and will be updated as necessary. While I will announce any substantive changes, you are expected to keep track of revised readings, assignments, and due dates.
+
+Please submit all assignments in Canvas, except for the midterm and final exams. I will not accept emailed or paper copies of assignments for any reason.
+
+You are expected to attend each class and to participate actively (exceptions made only for health reasons, religious holidays, and other university-approved excuses). Whether or not students attend class consistently is the best indicator of how well they will do in the class. Participation grades will be reduced due to repeated absences. If you wish to be excused for an absence, please contact me before the absence if possible, or as soon as possible after the absence if it is an emergency. I understand that life happens, and I will do my best to work with you.
+
+Computers, phones, and the like are to be used only for course work while class is in session. Please don't distract your neighbors!
+
+Complete all the readings before the start of each class. No unexcused late work will be accepted. No work will be accepted after the last day of class for any reason. I will discuss grades only in conversation during office hours, not via correspondence.
+
+Class communications will be sent through Canvas or through your GMU email account, both of which you must check.
+
+If the campus closes, or if a class meeting needs to be canceled or adjusted due to weather or some other concern, students should check for updates on how to continue learning and for information about any changes assignments.
+
+Unless otherwise specified, you should work on your own for assignments. In general, every source that you use should be acknowledged in a parenthetical citation, footnote, or bibliography entry. Sources must be adequately paraphrased, meaning (at a minimum) that word choice, sentence and paragraph structure, and the order of ideas must be made your own. Whenever you use others' exact words, you must mark them as such by quotation marks or block quotations with accompanying citations. Plagiarism consists of presenting the writing, research, or analysis of others as one's own. It applies not only to using the text of another author's work verbatim without quotation marks and accurate citations but also to the taking of specific information, analysis or opinions---even if not in the exact words of the author---and presenting them without citation in one's own paper. Using AI-assistance for any paper, quiz, exam, or assignment is also plagiarism. Any instance of plagiarism will result in, at minimum, the student receiving a grade of 0 on the assignment, and the student will not be given the opportunity to resubmit the assignment.
+
+George Mason University has an [Honor Code](https://oai.gmu.edu/mason-honor-code/), which requires all members of this community to maintain the highest standards of academic honesty and integrity. Cheating, plagiarism, lying, and stealing are all prohibited. All violations of the Honor Code will be reported to the Honor Committee.
+
+See the George Mason University [catalog](http://catalog.gmu.edu/) for general policies, as well as the university [statement on diversity](http://ctfe.gmu.edu/professional-development/mason-diversity-statement/).
+
+If you are a student with a disability and you need academic accommodations, please see me and contact the [Office of Disability Resources](https://ds.gmu.edu/). I am more than happy to assist you in succeeding in the course, but all academic accommodations must be arranged through that office.
+
+Students are responsible for verifying their enrollment in this class. Schedule adjustments should be made by the deadlines published in the Schedule of Classes. (Deadlines each semester are published in the Schedule of Classes available from the [Registrar's website](https://registrar.gmu.edu/).)
+
+"Render therefore to all their dues": This syllabus is based on versions of this class taught with or by my colleagues John Turner and Mack Holt.

--- a/content/courses/scriptures.2026/index.md
+++ b/content/courses/scriptures.2026/index.md
@@ -1,0 +1,329 @@
+---
+title: American Scriptures
+semester: Spring
+year: 2026
+department: Department of History and Art History
+university: George Mason University
+coursenum: HIST/RELI 334
+courseurl: https://historyarthistory.gmu.edu/courses/hist334
+credits: 3
+meets: Tuesdays and Thursdays, 10:30am to 11:45am
+room: Planetary Hall 124
+instructor: Lincoln Mullen
+instructorurl: https://lincolnmullen.com
+email: lmullen@gmu.edu
+office: Research Hall 483
+officehours: "By appointment"
+toc: true
+draft: false
+---
+
+## Course description
+
+In this course, students will analyze texts that Americans have treated as “scripture.” Students will read texts that present themselves as scripture, such as selections from the Book of Mormon and a Holy Sacred and Divine Roll and Book (a Shaker text). They will also read texts that have attained a sort of canonicity within American culture, such as the Declaration of Independence and Martin Luther King Jr.’s “Letter from Birmingham Jail.” Students will thus gain more than a valuable familiarity with a variety of American religious traditions. They will also reflect on the way that, even in a digital age, texts continue to shape American identity. Finally, the course invites students to reflect on the meaning and function of “scripture.” Although many Americans reflexively define scripture as “the Word of God” or think of the Bible or the Qur’an, the scholar Wilfred Cantwell Smith cautions that “no text is a scripture in itself and as such. People—a given community—make a text into scripture, or keep it scripture.” Along those lines, Americans, and different groups of Americans, have granted such authority to a wide variety of texts.
+
+## Learning goals
+
+In this course you will
+
+- gain familiarity with a variety of American religious traditions, including Shakerism, Mormonism, Christian Science, Adventism, Judaism, and the Nation of Islam.
+- develop your ability to carefully analyze texts, paying attention to issues such as authorship, intertextuality, and reception.
+- articulate historical insights clearly and memorably in prose.
+
+This class fulfills the Mason Core Literature requirement. The readings and assignments are designed to fulfill these learning goals. Students will be able to
+
+- read for comprehension, detail, and nuance.
+- identify the specific literary qualities of language as employed in the texts they read.
+- analyze the ways specific literary devices contribute to the meaning of a text.
+- identify and evaluate the contribution of the social, political, historical, and cultural contexts in which a literary text is produced.
+- evaluate a critical argument in others' writing as well as their own.
+
+## Essential information
+
+This class will include a combination of lecture, discussion, and active learning. Doing the reading is absolutely essential. There will be a handwritten reading quiz every class period: if you've done the reading, you can expect to do well on the quizzes. Attend class having read any assigned material and be prepared to discuss or otherwise engage with those readings in class. You must have a copy of the texts assigned for each day available to you during class (electronic copies are fine). The quiz will do double duty for attendance taking.
+
+You are always welcome to talk with me during office hours. To do so, please [book an appointment](/page/office-hours/). If the scheduled times don't work for you, contact me and suggest a few other times that would work for you. I try to come to class early and stay briefly after class for short conversations but I may not always be able to do so.
+
+You can contact me via the messaging feature of Canvas or email (<lmullen@gmu.edu>). You can generally expect a response within 48 hours, though never on the weekend.
+
+**Required books.** The following books are required. Any edition will do.
+
+- Maffly-Kipp, Laurie F. _American Scriptures: An Anthology of Sacred Writings_. Penguin, 2010. ISBN: 978-0143106197.
+- Prothero, Stephen. _The American Bible: How Our Words United, Divide, and Define a Nation_. HarperOne, 2012. ISBN: 978-0062123459.
+- Rothschild, Mike. _The Storm Is Upon Us: How QAnon Became a Movement, Cult, and Conspiracy Theory of Everything_. Melville House, 2022. ISBN: 978-1685890186.
+
+Other readings will be available on Canvas or through the GMU libraries.
+
+## Assignments
+
+This class will have two essential activities. The first is reading texts and then discussing them and writing about them. Most days we will read primary source texts which have been regarded as scripture by one group or another. While I will give lectures to set the context, much of our class time will be spent discussing these texts. You will also be asked to write several short analytical essays about these texts. I may bring additional sources to class for us to read together in class.
+
+The second main activity for this class will be creating a collaborative explanation of the Qanon conspiracy theory and the "Q drops" as a new American scripture. The purpose of this capstone assignment is to collaboratively understand a recent phenomenon in American life in terms of what we have learned in this course about how communities and texts co-constitute one another.
+
+**Reading quizzes and class participation (20 points):** Every class will have a brief quiz over the assigned reading, which will pose no difficulty if you have read thoroughly. I will also give you a few participation assignments to prompt class discussion (some of these are listed on the syllabus already). Participation in class discussions is vital. I will assign a grade for this section at the end of the semester.
+
+**Short response papers (4 papers × 10 points/paper = 40 points):** You will write four short papers responding to some texts that we have read. There are six possible papers throughout the semester; the prompts are listed in the schedule below. The papers should be a minimum of three and a maximum of five double-spaced pages; 12pt font; 1 inch margins; footnotes in the Chicago Manual of Style format. These are due at the start of class; no exceptions or extensions.
+
+**Qanon assignment (40 total points):** As a capstone assignment for the course, we will work collaboratively to explain the Qanon conspiracy theory as a new American scripture, using what we have learned from our readings and class discussions. We will allot a significant part of our time to working on this collaboratively in class.
+
+The purpose of this assignment is to use the methods of studying scripture which we have learned about in the course, and to apply them to the Q "drops." The three main methods we have covered are these:
+
+- Sources and origins (Where did this text come from? Who created it? Why?)
+- Exegesis (How has this text been interpreted? By whom? How do they come to that interpretation?)
+- Function (What work does this text do in the world? To what purposes has it been put? How has it been received?)
+
+You will work in groups of three or at most four. Select one Q drop from a website such as qalerts.app. You must also find another source online which interprets that drop. This source could be, for example, a set of tweets or a blog post or a YouTube video or an online forum thread. This will be the basis of most of your writing. Your final project will be a written analysis of the text you have chosen. You are encouraged to include supporting material in the form of screenshots, images, and so forth as appropriate, though those do not count towards the page requirements. Page requirements are 12pt font, single-spaced. Cite all sources, primary or secondary, using footnotes in the Chicago Manual of Style format. There is no need to include a bibliography. The project should have the following structure:
+
+- Introduction (approximately one page)
+- Sources and origins (at least two but no more than three pages)
+- Exegesis (at least two but no more than three pages)
+- Function (at least two but no more than three pages)
+- Conclusion (approximately one page)
+
+For each of those sections, be specific about the text you have chosen. Do not write a general report on Qanon. Include background on Qanon as necessary, but discuss your drop and its reception in particular. Each student should submit the report separately in Canvas as a PDF, but include the names of everyone on the project together.
+
+Final grades will be calculated using this scale: A = 93--100, A- = 90--92, B+ = 88--89, B = 83--87, B- = 80--82, ... F = 0--59. All grades will be calculated in Canvas.
+
+## Schedule
+
+### Tuesday, Jan. 20: Introduction
+
+In class: Abraham Lincoln, [Second Inaugural Address](https://www.loc.gov/resource/rbpe.24203400/).
+
+In class: What do different Bibles contain?
+
+### Thursday, Jan. 22: What is scripture?
+
+Read:
+
+- Wilfred Cantwell Smith, _What Is Scripture? A Comparative Approach_ (Fortress Press, 1993), ch. 1. PDF on Canvas.
+- Stephen Stein, "America's Bibles: Canon, Commentary, and Community," _Church History_ 64, no. 2 (1995): 169--184. [Article through GMU libraries](http://mutex.gmu.edu/login?url=https://www.jstor.org/stable/3167903).
+
+### Thursday, Jan. 29: Exodus
+
+Read:
+
+- "The Exodus Story," in Prothero, 18--33.
+- John Winthrop, "A Model of Christian Charity," in Prothero, 34--51.
+- Eddie S. Glaude Jr., _Exodus! Religion, Race, and Nation in Early Nineteenth-Century Black America_ (University of Chicago Press, 2000), ch. 2. PDF on Canvas.
+
+### Tuesday, Feb. 3: Texts of the American founding
+
+Participation assignment: bring a sacred text of your choice to class, with a very brief written description of it.
+
+Read:
+
+- Thomas Paine, _Common Sense_, in Prothero, 52--72.
+- Declaration of Independence, in Prothero, 73--97.
+- Thomas Jefferson, "Life and Morals of Jesus of Nazareth," in Maffly-Kipp, 1--31.
+
+### Thursday, Feb. 5: Shakers and Adventists
+
+Read:
+
+- "A Holy, Sacred and Divine Roll and Book," in Maffly-Kipp, 63--93.
+- "The Great Controversy between Christ and Satan," in Maffly-Kipp, 266--289.
+
+### Tuesday, Feb. 10: Latter-day Saints
+
+Read:
+
+- "The Book of Mormon," in Maffly-Kipp, 32--62.
+- "A Warning to the Latter Day Saints," in Maffly-Kipp, 94--115.
+- John G. Turner, _Joseph Smith_, chs. 3--6. PDF on Canvas.
+
+### Thursday, Feb. 12: Latter-day Saints
+
+**Response paper.** Compare selections from the Book of Mormon, Joseph Smith's History, and Doctrine and Covenants 89. These texts all function as authoritative "scripture" for several American religious groups, yet they are very different sorts of texts. Consider differences in genre, rhetoric, literary devices, and setting. What makes these varied texts each function as scripture?
+
+Read:
+
+- Joseph Smith History. PDF on Canvas.
+- Doctrine and Covenants 89. PDF on Canvas.
+
+### Tuesday, Feb. 17: Texts of the Civil War
+
+Read:
+
+- Abraham Lincoln, "Gettysburg Address," in Prothero, 330--345.
+- Maria Stewart, "Religion and the Pure Principles of Morality," excerpts from Valerie C. Cooper, _Word, Like Fire: Maria Stewart, the Bible, and the Rights of African Americans_ (University of Virginia Press, 2011). PDF on Canvas.
+- Robert L. Dabney, _A Defence of Virginia_. PDF on Canvas.
+
+### Thursday, Feb. 19: Race in the literary canon
+
+Read:
+
+- Harriet Beecher Stowe, _Uncle Tom's Cabin_, in Prothero, 162--180.
+- Mark Twain, _Adventures of Huckleberry Finn_, in Prothero, 181--198.
+
+### Tuesday, Feb. 24: Spiritualism and Christian Science
+
+Read:
+
+- Principles of Nature, in Maffly-Kipp, 116--139.
+- Science and Health, in Maffly-Kipp, 194--218.
+
+### Thursday, Feb. 26: Metaphysical religion
+
+Read:
+
+- OAHSPE, in Maffly-Kipp, 219--240.
+- Aquarian Gospel of Jesus the Christ, 378--406.
+
+### Tuesday, Mar. 3: Tarot
+
+Participation assignment: find a deck of tarot cards. Ideally you will find paper cards, but you can also find them in an app or online. Select three cards that appeal to you. Look for guides to tarot (print or online) and briefly summarize the meanings of those cards. Create a document with your notes (including the sources). Bring the cards and your notes to class.
+
+Read:
+
+- _Tarot and Divination Cards_, chs. 1--2. PDF on Canvas.
+- Caponi, _Guided Tarot_, chs. 1--2. PDF on Canvas.
+
+### Thursday, Mar. 5: Texts as material objects
+
+Read:
+
+- Paul C. Gutjahr, _An American Bible: A History of the Good Book in the United States, 1777--1880_ (Stanford University Press, 1999). PDF on Canvas.
+- Colleen McDannell, "The Bible in the Victorian Home," from _Material Christianity: Religion and Popular Culture in America_ (Yale University Press, 1995). PDF on Canvas.
+
+### GMU spring break, March 9--13
+
+### Tuesday, Mar. 17: The Qu'ran in America
+
+**Response paper.** What circumstances shaped Omar ibn Said's conclusion? How does he make use of both the Qur'an and the Bible in his life story?
+
+Read:
+
+- Omar ibn Said, _Autobiography of Omar ibn Said, Slave in North Carolina_. PDF on Canvas.
+- Elijah Muhammad, _Message to the Blackman in America_. PDF on Canvas.
+- Amina Wadud, _Qu'ran and Woman_, from _Columbia Sourcebook of Muslims in the United States_. PDF on Canvas.
+
+### Thursday, Mar. 19: Women's interpretations of the Bible
+
+**Response paper.** What arguments do Stanton and Bushnell advance about women and the Bible? What strategies do they employ for reading the text and for understanding it as authoritative?
+
+Read:
+
+- Elizabeth Cady Stanton, _The Woman's Bible_, in Maffly-Kipp, 345--377.
+- Katherine Bushnell, _God's Word to Women_. PDF on Canvas.
+
+### Tuesday, Mar. 24: The Jewish Bible
+
+Read:
+
+- Jonathan D. Sarna, “The Bible and Judaism in America,” in _The Oxford Handbook of the Bible in America_, ed. Paul C. Gutjahr (Oxford University Press, 2017), 505--16. PDF on Canvas.
+- George Washington, letter to the Hebrew Congregation in Newport ("To Bigotry No Sanction"). PDF on Canvas.
+
+### Thursday, Mar. 26: Horoscopes
+
+Participation assignment: download the Costar app (or use the website). Sign up for the free service and input your details. Look at your horoscope for as many days as possible. Most important, look at your birth chart. Write up a few paragraphs of reflections: do these horoscopes resonate with you? Do you see yourself in your birth chart? Come prepared to discuss how you've seen how astrology works and what it is like to access a sacred text via an app. Congratulations: most people know their sun sign, but now you know your moon sign and rising too. ;-)
+
+### Tuesday, Mar. 31: Witchcraft
+
+Read:
+
+- Tara Isabella Burton, _Strange Rites: New Religions for a Godless World_ (PublicAffairs, 2020), ch. 6. PDF on Canvas.
+- Margot Adler, _Drawing Down the Moon_, chs. 4--5. PDF on Canvas.
+
+### Thursday, Apr. 2: Harry Potter as scripture
+
+Read:
+
+- Margot Adler, _Drawing Down the Moon_, ch. 10. PDF on Canvas.
+- Tara Isabella Burton, _Strange Rites: New Religions for a Godless World_ (PublicAffairs, 2020), ch. 4. PDF on Canvas.
+
+### Tuesday, Apr. 7: How the Bible was used
+
+**Response paper.** Pick two verses from the Christian Bible that relate to one another. Using [_America's Public Bible_](https://americaspublicbible.org), trace the trends in how these verses were quoted over time. Then follow the links to _Chronicling America_ to read the context of those quotations in newspapers. How were those verses used? Were used differently by different people? How did their interpretations change over time? Include footnotes to and quotations from the newspapers.
+
+Browse:
+
+- Lincoln A. Mullen, _America’s Public Bible: A Commentary_ (Stanford University Press, 2023): <https://americaspublicbible.org>, <https://doi.org/10.21627/2022apb>.
+
+Read:
+
+- Hentschel, "The King James Only Movement," in _The Oxford Handbook of the Bible in America_. PDF on Canvas.
+
+### Thursday, Apr. 9: Museum of the Bible
+
+**Response paper.** Consider the Museum of the Bible not as a secondary source but as a primary source. What narrative is it trying to tell? What evidence and texts does it use in support? To whom is this narrative addressed? Answer these questions in an essay which explicates the Museum of the Bible as a text. Feel free to look for other news stories as well, in particular about the antiquities trade.
+
+Read each of the following brief essays:
+
+- Kelly Gannon and Kimberly Wagner, “Museum of the Bible, Washington, D.C.,” _Journal of American History_ 105, no. 3 (2018): 618--25, <http://mutex.gmu.edu/login?url=https://doi.org/10.1093/jahist/jay283>.
+- James Bielo, “Quality: D.C.’s Museum of the Bible and Aesthetic Evaluation,” _Material Religion_ 15, no. 1 (2019): 131--32, <http://mutex.gmu.edu/login?url=https://doi.org/10.1080/17432200.2018.1535015>.
+- Jana Mathews, “The Museum of the Bible’s ‘Fake’ History of the Bible,” _Material Religion_ 15, no. 1 (2019): 133--36, <http://mutex.gmu.edu/login?url=https://doi.org/10.1080/17432200.2018.1535017>.
+- Jill Stevenson, “Narrative Space: Performing Progress at the Museum of the Bible,” _Material Religion_ 15, no. 1 (2019): 136--40, <http://mutex.gmu.edu/login?url=https://doi.org/10.1080/17432200.2018.1535018>.
+
+Read at least one of the following:
+
+- Emma Green, "[The Museum That Places the Bible at the Heart of America's Identity](https://www.theatlantic.com/politics/archive/2017/11/the-museum-of-the-bible-is-the-ultimate-symbol-of-americas-religious-identity/546650/)," _The Atlantic_, November 26, 2017.
+- Dalia Hatuga, "[What's Missing from the Museum of the Bible](https://www.theatlantic.com/international/archive/2017/11/museum-of-the-bible-arabic-koran/546224/)," _The Atlantic_, November 18, 2017.
+- Katherine Stewart, "[The Museum of the Bible Is a Safe Space for Christian Nationalists](https://www.nytimes.com/2018/01/06/opinion/sunday/the-museum-of-the-bible-is-a-safe-space-for-christian-nationalists.html)," _New York Times_, January 6, 2018.
+- Peggy McGlone, "[Will Money from Conservative Christians Sway Bible Museum’s Professed Mission?](https://www.washingtonpost.com/entertainment/museums/will-money-from-conservative-christians-sway-bible-museums-professed-mission/2017/11/02/5d8b7a18-ba86-11e7-9e58-e6288544af98_story.html?noredirect=on&utm_term=.7f9f7186269a)" _Washington Post_, November 2, 2017.
+- David Weaver-Zercher, "[The Museum of Whose Bible?](https://www.christiancentury.org/review/books/museum-of-whose-bible)," _The Christian Century_, October 3, 2017.
+- Martyn Wendell Jones, "[Inside the Museum of the Bible](https://www.christianitytoday.com/ct/2017/november/inside-museum-of-bible.html)," _Christianity Today_, October 20, 2017.
+- Diana Muir Appelbaum, "[Who's Afraid of the Museum of the Bible?](https://mosaicmagazine.com/essay/2018/01/whos-afraid-of-the-museum-of-the-bible/)," _Mosaic_, January 2, 2018.
+- Gordon Haber, "[We Went To The Museum Of The Bible---So You Don't Have To](https://forward.com/culture/art/388102/we-went-to-the-museum-of-the-bible-so-you-dont-have-to)," _Forward_, November 21, 2017.
+
+### Tuesday, Apr. 14: Qanon
+
+Read:
+
+- Rothschild, _The Storm Is Upon Us_, introduction and part 1.
+
+### Tuesday, Apr. 21: Qanon
+
+Read:
+
+- Rothschild, _The Storm Is Upon Us_, parts 2 and 3.
+
+### Thursday, Apr. 23: Qanon
+
+Read:
+
+- Michael J. Altman and Jerome Copulsky, _Uncivil Religion: January 6, 2021_, University of Alabama and Smithsonian National Museum of American History (2022): <http://uncivilreligion.org/>.
+
+### Tuesday, Apr. 28: Qanon
+
+Read:
+
+- Mia Bloom and Sophia Moskalenko, _Pastels and Pedophiles: Inside the Mind of QAnon_ (Stanford University Press, 2021), ch. 3. PDF on Canvas.
+
+### Thursday, Apr. 30: Civil rights
+
+**Response paper.** Compare the rhetoric and arguments made in King’s “Letter” and Malcolm X’s “The Ballot or the Bullet.” What are the settings for these two texts? What circumstances explain the differences in their arguments?
+
+Participation assignment: bring a sacred song or hymn to class. Be prepared to justify why it is sacred and to describe how it is used.
+
+Read (optional):
+
+- Martin Luther King Jr., “Letter from Birmingham Jail," in Prothero, 462--482.
+- Malcom X, _Autobiography of Malcom X_, in Prothero, 308--328.
+- Malcolm X, "The Ballot or the Bullet." PDF on Canvas.
+
+### Qanon final assignment due Monday, May 11, at 11:59pm
+
+## Fine print
+
+You are expected to attend each class and to participate actively (exceptions made only for health reasons, religious holidays, and other university-approved excuses). Whether or not students attend class consistently is the best indicator of how well they will do in the class. Participation grades may be reduced due to repeated absences. If you wish to be excused for an absence, please email me before the absence if possible, or as soon as possible after the absence. I understand that life happens, and I will do my best to work with you.
+
+Computers, phones, and the like are to be used only for course work while class is in session. Please don't distract your neighbors.
+
+Complete all the readings before the start of each class. No unexcused late work will be accepted. No work will be accepted after the last day of class. I will discuss grades only in conversation during office hours, not over email.
+
+Class communications will be sent to your GMU email account or via Canvas, which you must check.
+
+If the campus closes, or if a class meeting needs to be canceled or adjusted due to weather or some other concern, students should check Canvas for updates on how to continue learning and for information about any changes assignments.
+
+Unless otherwise specified, you should work on your own for assignments. In general, every source that you use should be acknowledged in a note or bibliography entry. Sources must be adequately paraphrased, meaning (at a minimum) that word choice, sentence and paragraph structure, and the order of ideas must be made your own. Whenever you use others' exact words, you must mark them as such by quotation marks or block quotations with accompanying citations. Plagiarism consists of presenting the writing, research, or analysis of others as one's own. It applies not only to using the text of another author's work verbatim without quotation marks and accurate citations but also to the taking of specific information, analysis or opinions---even if not in the exact words of the author---and presenting them without citation in one's own paper. Using AI-assistance to write (as opposed to research) any paper is also plagiarism. Any instance of plagiarism will result in, at minimum, the student receiving a grade of 0 on the assignment, and the student will not be given the opportunity to rewrite the paper.
+
+George Mason University has an [Honor Code](https://oai.gmu.edu/mason-honor-code/), which requires all members of this community to maintain the highest standards of academic honesty and integrity. Cheating, plagiarism, lying, and stealing are all prohibited. All violations of the Honor Code will be reported to the Honor Committee.
+
+See the George Mason University [catalog](http://catalog.gmu.edu/) for general policies, as well as the university [statement on diversity](http://ctfe.gmu.edu/professional-development/mason-diversity-statement/).
+
+If you are a student with a disability and you need academic accommodations, please see me and contact the [Office of Disability Resources](https://ds.gmu.edu/). All academic accommodations must be arranged through that office.
+
+Students are responsible for verifying their enrollment in this class. Schedule adjustments should be made by the deadlines published in the Schedule of Classes. (Deadlines each semester are published in the Schedule of Classes available from the [Registrar's website](https://registrar.gmu.edu/).)
+
+"Render therefore to all their dues": This syllabus is based on a version of this class taught with my colleague John Turner.


### PR DESCRIPTION
Addresses #158.

Two courses were taught out of Canvas rather than on this site. This PR imports their syllabi as regular course page bundles:

- `content/courses/scriptures.2026/` — American Scriptures, HIST/RELI 334, Spring 2026 (from Canvas course 71778). The day-by-day schedule was reconstructed from Canvas Modules, and the response-paper prompts, participation assignments, and the full Qanon capstone assignment were pulled from the Canvas assignment pages.
- `content/courses/christianity.2024/` — Global History of Christianity, HIST 384/RELI 384, Fall 2024 (from Canvas course 25783). Course description, goals, and policies come from the course home page; the reading schedule from the syllabus page; and the nine short-writing prompts from the assignment pages, embedded at their class days.

The two rows on the teaching page (`content/courses/_index.md`) now link to the new bundles instead of Canvas.

Notes:

- No PDFs or student information were copied. Readings that existed only as Canvas attachments are cited bibliographically with "PDF on Canvas," following the "PDF on Blackboard" convention in older syllabi.
- `courseurl` points to the department catalog pages (historyarthistory.gmu.edu/courses/hist334 and /hist384) because the per-section pages for these terms are not easily discoverable; swap in section URLs if you have them.
- Meeting times (Tu/Th 10:30–11:45am for both) confirmed by Lincoln, since Canvas does not record them.
- Dropped the stale "the Achebe reading in particular" clause from the Fall 2024 required-readings paragraph (Achebe was not assigned in 2024; leftover from the 2023 version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)