### PR TITLE
Point duplicated syllabus PDFs at their R2 copies

### DIFF
--- a/content/blog/2012-08-27-religious-pluralism-and-the-american-state/index.md
+++ b/content/blog/2012-08-27-religious-pluralism-and-the-american-state/index.md
@@ -13,7 +13,7 @@ This fall I'll be teaching a university writing seminar titled 'Religious Plural
 
 <!--more-->
 
-I've made the [syllabus](religious-pluralism.syllabus.2012-fall.pdf) available online and I've put up a basic [course website](http://lincolnmullen.com/courses/uws/).
+I've made the [syllabus](https://files.lincolnmullen.com/syllabi/religious-pluralism.syllabus.2012-fall.pdf) available online and I've put up a basic [course website](http://lincolnmullen.com/courses/uws/).
 
 Here is the course description:
 

--- a/content/blog/2017-01-20-syllabi-for-spring-2017/index.md
+++ b/content/blog/2017-01-20-syllabi-for-spring-2017/index.md
@@ -16,7 +16,7 @@ This semester I am teaching three courses, two undergraduate and one graduate.
 
 Here are the syllabi and course descriptions.
 
-**Global History of Christianity, [syllabus](Global-History-Christianity.spring-2017.pdf)**
+**Global History of Christianity, [syllabus](https://files.lincolnmullen.com/syllabi/Global-History-Christianity.spring-2017.pdf)**
 
 > This course is organized around a comparative examination of the many forms of global Christianity over the past two thousand years. Chronologically, it begins with the ancient Jewish, Greek, and Roman contexts of early Christianity and continues through the present. Students will become familiar with many kinds of Christianity across the globe, including Asian, African, Latin American, European, and North American Christianities. In each geographic and chronological contexts, students will explore several themes: use of sacred texts and the experiences of a typical church service, the relationship between Christianity and politics, and cultural aspects such as marriage and sexuality. Students will also consider Christianity as a series of global systems organized around missions, migration, trade, and warfare.
 


### PR DESCRIPTION
Closes #163.

Takes **option 1** from the issue: consolidate on R2 and leave `/courses/` as the canonical index of syllabi. That matches how the other 13 syllabi are already handled.

### This also fixes a live 404

The issue described this as a cosmetic consistency problem — "nothing is broken, both URLs work." That turns out not to hold for the deployed site. Neither bundle PDF was ever committed:

```
?? content/blog/2012-08-27-religious-pluralism-and-the-american-state/religious-pluralism.syllabus.2012-fall.pdf
?? content/blog/2017-01-20-syllabi-for-spring-2017/Global-History-Christianity.spring-2017.pdf
```

They are untracked (and not gitignored), so they exist only in the local working tree. The Cloudflare build never sees them, which means the bare-filename links resolved to a missing file on *every* page that rendered them, not just the list pages and feeds. Locally it looks fine because Hugo copies the untracked files into `public/`.

### Changes

Two one-line link changes:

| Post | Was | Now |
|---|---|---|
| `2017-01-20-syllabi-for-spring-2017` | `Global-History-Christianity.spring-2017.pdf` | `https://files.lincolnmullen.com/syllabi/…` |
| `2012-08-27-religious-pluralism-and-the-american-state` | `religious-pluralism.syllabus.2012-fall.pdf` | `https://files.lincolnmullen.com/syllabi/…` |

The 2017 post already linked its other two syllabi (`digital-past.2017.pdf`, `clio2.2017.pdf`) to R2, so it is now internally consistent.

### Verification

`hugo --cleanDestinationDir --minify` builds clean, and both posts render the R2 URLs. No bare-filename `.pdf` hrefs remain anywhere in the build output.

### Note — not touched by this PR

Three other untracked PDFs in the working tree are linked by bare filename the same way and will have the same problem if they are not committed:

- `2013-01-10-empowering-the-humanities-speaker-series-at-wentworth/wit.empowering-humanities.pdf`
- `2013-01-10-empowering-the-humanities-speaker-series-at-wentworth/wit.unsworth.pdf`
- `2015-04-07-practical-problems-in-teaching-digital-history/practical-problems-in-teaching-dh.pdf`

Those are conference posters and a handout rather than syllabi, so they do not belong in `syllabi/` on R2 and are outside this issue's scope. They look like work in progress on your end — committing them to their page bundles is probably the right call, and the render hook will then resolve them correctly.

The two syllabus PDFs still sitting untracked in your working tree can now be deleted; I left them alone rather than removing files git does not track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)