### PR TITLE
Embed citation metadata so Zotero saves posts as blog posts

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -28,6 +28,9 @@
 	<!-- OpenGraph meta tags -->
 	{{ partial "opengraph.html" . }}
 
+	<!-- Citation metadata for Zotero and other reference managers -->
+	{{ partial "citation-metadata.html" . }}
+
 	<!-- CSS and fonts -->
 	<link rel="dns-prefetch" href="//cdn.jsdelivr.net">
 	<link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>

--- a/layouts/partials/citation-metadata.html
+++ b/layouts/partials/citation-metadata.html
@@ -1,0 +1,77 @@
+{{- /* Machine-readable citation metadata, so that Zotero (and anything else
+reading embedded metadata) saves a post as a blog post rather than a bare web
+page. The visible Chicago-style citations in layouts/blog/single.html are the
+human-readable counterpart of this.
+
+Zotero reads these through its "Embedded Metadata" translator, which hands
+recognized prefixes to the RDF translator. Three details drive what is emitted
+here:
+
+  1. Type detection has a strict precedence order, and "z:itemType" sits at the
+     top of it. That matters because opengraph.html emits og:type=website on
+     non-article pages, which otherwise forces the type to "webpage". Without
+     an explicit statement a post is saved as a webpage. "rdf:type" is a
+     standards-flavored belt-and-braces duplicate; the two agree, and the
+     Zotero-private one wins.
+
+  2. The Highwire "citation_" family is applied last and overwrites the RDF
+     layer, which is why citation_date and citation_abstract are used here:
+     they beat article:published_time (an RFC3339 timestamp, where a plain date
+     reads better) and og:description (truncated to 200 characters).
+
+  3. Some citation_ tags hard-override the item type and must never appear on
+     these pages: citation_journal_title, citation_book_title,
+     citation_inbook_title, citation_conference_title, citation_conference,
+     citation_dissertation_institution, and
+     citation_technical_report_institution. citation_title is deliberately
+     omitted too -- it is not fatal on its own, but it makes journalArticle the
+     fallback type, so any future slip in the tags above would silently
+     downgrade posts. dc:title carries the title instead.
+
+Prefixes need no xmlns or "prefix" attribute; dc, dcterms, z and rdf are all
+recognized by default. */ -}}
+{{- if and .IsPage (in (slice "blog" "newsletter") .Section) -}}
+
+{{- /* Title. Titles are Markdown, so render inline and strip tags the same way
+       the visible headings do. Untitled micro posts borrow the wording of
+       their hidden heading in blog/single.html. */ -}}
+{{- $title := "" -}}
+{{- if .Title -}}
+  {{- $rendered := .RenderString (dict "display" "inline") .Title | plainify -}}
+  {{- if eq .Section "newsletter" -}}
+    {{- $title = printf "%s #%s: %s" .Site.Params.newsletterTitle .Slug $rendered -}}
+  {{- else -}}
+    {{- $title = $rendered -}}
+  {{- end -}}
+{{- else -}}
+  {{- $title = printf "Post from %s" (.Date.Format site.Params.dateForms.long) -}}
+{{- end -}}
+
+{{- /* Abstract: the author's own description when there is one, otherwise the
+       summary, kept to a length that reads as an abstract. */ -}}
+{{- $abstract := "" -}}
+{{- if .Description -}}
+  {{- $abstract = .Description -}}
+{{- else -}}
+  {{- with .Summary -}}
+    {{- $abstract = . | plainify | strings.TrimSpace | truncate 400 -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* Publication title. Zotero maps this to the "Blog" field. */ -}}
+{{- $source := .Site.Params.blogFeedTitle -}}
+{{- if eq .Section "newsletter" -}}
+  {{- $source = .Site.Params.newsletterTitle -}}
+{{- end -}}
+
+<!-- Citation metadata (Zotero) -->
+<meta name="z:itemType" content="blogPost">
+<meta name="rdf:type" content="http://schema.org/BlogPosting">
+<meta name="dc:title" content="{{ $title }}">
+<meta name="dc:creator" content="{{ .Site.Params.author.name }}">
+<meta name="dc:source" content="{{ $source }}">
+<meta name="citation_date" content="{{ .Date.Format site.Params.dateForms.machine }}">
+{{- with $abstract }}
+<meta name="citation_abstract" content="{{ . }}">
+{{- end }}
+{{- end -}}


### PR DESCRIPTION
Closes #154.

`layouts/blog/single.html` already renders Chicago-style footnote and bibliography citations for readers. This gives reference managers the same information.

### What was actually happening

Not what I first assumed. Posts weren't being mis-typed as journal articles — they were being saved as **`webpage`**. The pages produce RDF statements (every `og:*` tag becomes one) but no type statement, so Zotero's detection fell through to its `webpage` default.

### The tags

Emitted on blog and newsletter **single pages only**:

```html
<meta name="z:itemType" content="blogPost">
<meta name="rdf:type" content="http://schema.org/BlogPosting">
<meta name="dc:title" content="…">
<meta name="dc:creator" content="Lincoln Mullen">
<meta name="dc:source" content="Lincoln Mullen's blog">
<meta name="citation_date" content="2017-01-20">
<meta name="citation_abstract" content="…">
```

Three things about Zotero's pipeline drove these choices:

1. **`z:itemType` sits at the top of the precedence chain.** That matters specifically because `opengraph.html` emits `og:type=website` on non-article pages, which otherwise pins the type to `webpage`. `rdf:type` restates it in a standards vocabulary as belt-and-braces; the two agree.
2. **The Highwire `citation_` family is applied *after* the RDF layer and overwrites it.** So `citation_date` beats `article:published_time` (an RFC3339 timestamp, where a plain `2017-01-20` reads better in a bibliography), and `citation_abstract` beats `og:description` (truncated to 200 characters).
3. **Some `citation_` tags hard-override the item type.** `citation_journal_title`, `citation_book_title`, `citation_inbook_title`, `citation_conference_title`, `citation_conference`, `citation_dissertation_institution`, and `citation_technical_report_institution` must never appear here. The partial documents this so it isn't undone later.

`citation_title` is deliberately **omitted**. It's harmless next to an explicit type statement, but it makes `journalArticle` the *fallback* type — so if the type tags were ever dropped or typo'd, every post would silently downgrade to a journal article rather than a webpage. `dc:title` carries the title with no such failure mode. Worth knowing if you ever want Google Scholar indexing, which leans on the Highwire tags: that would be a deliberate trade-off, not something to add casually.

`dc:type` is also avoided — it works for detection, but Zotero copies the value verbatim into `websiteType`, so items would display a stray "Website Type: blogPost".

### Verification

Built and checked the rendered HTML:

| Case | `dc:title` |
|---|---|
| Titled post | `Syllabi for spring 2017` |
| Untitled micro post | `Post from 3 November 2022` |
| Newsletter issue | `Working on It #1: Love letter to the IndieWeb` |
| Home / courses / archive | *no tags emitted* |

Newsletter issues get `dc:source` = `Working on It`; blog posts get `Lincoln Mullen's blog`. Both map to Zotero's "Blog" field.

Titles are Markdown, so they're rendered inline and stripped the same way the visible headings are. All **259** `dc:title` tags were checked for leaked markup: **0** contain raw Markdown or HTML. `The return of the *longue durée*…` comes through as `The return of the longue durée in American religious history`.

### Not verified

I could not run Zotero itself here, so this is verified against the translator source rather than by a live save. Worth a quick check with Zotero's connector on one post of each kind before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)